### PR TITLE
Update Go to 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Build
       run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/garsue/watermillzap
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ThreeDotsLabs/watermill v1.3.2


### PR DESCRIPTION
Requried by https://github.com/garsue/watermillzap/pull/27

- go mod edit -go=1.19
- Update go-version in workflow
